### PR TITLE
Updated node-geocoder to version 3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "babel": "5.8.23",
     "chalk": "1.1.1",
-    "node-geocoder": "2.23.0",
+    "node-geocoder": "3.4.0",
     "uber-api": "0.3.3",
     "wifi-location": "0.0.1",
     "text-table": "0.2.0"


### PR DESCRIPTION
:rocket:

node-geocoder just published version 3.4.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 38 commits (ahead by 38, behind by 0).

- [28652a8](https://github.com/nchaulet/node-geocoder/commit/28652a8b7707a475b25823a90de2173f9adc59a5): 3.4.0
- [233d393](https://github.com/nchaulet/node-geocoder/commit/233d39372af0ff77f4aca5db26b7bf2114b4abcf): v3.4.0 changelog
- [edddd99](https://github.com/nchaulet/node-geocoder/commit/edddd9960d35983242c480febf77a38248618b46): Merge pull request #135 from magnushiie/master
- [e6e7e9d](https://github.com/nchaulet/node-geocoder/commit/e6e7e9d8741bcd210f81b04ed75b756048a38bae): Add Teleport geocoder
- [97fc0be](https://github.com/nchaulet/node-geocoder/commit/97fc0be9055df9afabcbdd169d2bff674e2f46af): Update CHANGELOG.md
- [da161d3](https://github.com/nchaulet/node-geocoder/commit/da161d320f5c175338a5374f8952c3e46ca608f3): 3.3.0
- [ac45200](https://github.com/nchaulet/node-geocoder/commit/ac452006df8511eab0ee579f985f1ac2470cca09): Merge pull request #132 from pbihler/addNomatimmapquestKey
- [4107206](https://github.com/nchaulet/node-geocoder/commit/41072067d054c13da2315406effcb1f50ed4569b): Merge pull request #133 from pbihler/provide-headers
- [707fc0d](https://github.com/nchaulet/node-geocoder/commit/707fc0db0f90a237cbedfedc26e440bcc54930c5): Extended default http adapter with the possibility to explicitely set http-get options
- [fa74184](https://github.com/nchaulet/node-geocoder/commit/fa7418481ce64eafcdeec1db494b1a8269d364eb): Added required api Key to Nominatimmapquestgeocoder
- [b9a0774](https://github.com/nchaulet/node-geocoder/commit/b9a07748329477f439cd952ff75f36d153b2bd31): fix version
- [ab4f233](https://github.com/nchaulet/node-geocoder/commit/ab4f233746d0cb5e58db3118ba78d02a87d2194a): 3.2.0
- [82c2fba](https://github.com/nchaulet/node-geocoder/commit/82c2fba09e4abdcbef71eca3af1f01c3688c2b41): 3.1.0
- [b38676c](https://github.com/nchaulet/node-geocoder/commit/b38676c33518e3fe6ec0b24d3945654b26bb9bd6): Merge pull request #129 from croweman/master
- [0c207e6](https://github.com/nchaulet/node-geocoder/commit/0c207e659729f67d2a31a1e881ce115c7a163170): Lee Crowe - Modified geocoderfactory to allow partial matches filter option to be parsed through to google geocoder, also added additional tests


There are 38 commits in total. See the [full diff](https://github.com/nchaulet/node-geocoder/compare/80be480fe378cd0a16d9f9163a4c39fc765c4e61...28652a8b7707a475b25823a90de2173f9adc59a5).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>