### PR TITLE
Updated jest-cli to version 0.5.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "surger": "./index.js"
   },
   "devDependencies": {
-    "jest-cli": "0.5.8"
+    "jest-cli": "0.5.10"
   }
 }


### PR DESCRIPTION
:rocket:

jest-cli just published version 0.5.10, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 15 commits (ahead by 15, behind by 0).

- [e83a131](https://github.com/facebook/jest/commit/e83a1312610eb716f1ade6ada8e8d6f81f76ed9b): 0.5.10
- [afe163a](https://github.com/facebook/jest/commit/afe163affbd5c6860bdacda5f0cb0e966dbbe754): Use determinstic stringification. fix #532
- [1355059](https://github.com/facebook/jest/commit/1355059e667e0ecced220aa73dfc04a3ae082b7c): Ignore cache directory from node-haste lookup. Fix #533
- [a8f6cf7](https://github.com/facebook/jest/commit/a8f6cf7150f010d65022a616655d47eee1f2b7fa): [npm] Add support for npm scoped packages
- [4ed0221](https://github.com/facebook/jest/commit/4ed0221372c082534bed59de38db37ff425ae6f5): Merge pull request #523 from Pajn/allow-watching-arbitrary-file-extensions
- [821775b](https://github.com/facebook/jest/commit/821775b18dfab688924ec691f044d08a34b7febf): feat: Add support for watching arbitrary file extensions
- [aee5ee5](https://github.com/facebook/jest/commit/aee5ee56501bae021d758c51e6e78c10822899e1): moduleMocker still can’t use ‘use strict’;
- [c843962](https://github.com/facebook/jest/commit/c8439620fd37e7fe19d66754961cb7e56d746907): Merge pull request #295 from fabiomcosta/master
- [731d91d](https://github.com/facebook/jest/commit/731d91d51fd7e4e5743fa7487c4e1bd21ad2fc99): Merge pull request #519 from silentroach/docs-preprocessorIgnorePatterns
- [98fbf3f](https://github.com/facebook/jest/commit/98fbf3f28fbff2181cb4450366e0163106755756): Merge pull request #518 from machadoum/master
- [c7730ee](https://github.com/facebook/jest/commit/c7730eed6f06944db54e0c58684e7428c12bafc6): Merge pull request #516 from yungsters/realpath
- [5ee328d](https://github.com/facebook/jest/commit/5ee328d5c7b9e05fddd5fd97541f799496889913): some info about config.preprocessorIgnorePatterns
- [4d442eb](https://github.com/facebook/jest/commit/4d442eb625821d870d75e6f4f9dad836e3a47fde): Issue #517 Bug on log error when verbose=true
- [92dcdb5](https://github.com/facebook/jest/commit/92dcdb537602a4e9e4d60ae629618e40bff1a054): Improve Symlink Fix
- [2e265d8](https://github.com/facebook/jest/commit/2e265d8a46cdca6ac2116686a0a091c5c10b5692): apply strict mode on moduleMocker.js

See the [full diff](https://github.com/facebook/jest/compare/699b614fcd70b9d1cec778eaf67efb38ce1a9cc0...e83a1312610eb716f1ade6ada8e8d6f81f76ed9b).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>